### PR TITLE
Add dependency for 'request' module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/GrammarMatcher')

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test-last": "yarn test `git st | grep test | awk '{print $NF}'`"
   },
   "dependencies": {
+    "request": "^2.34",
     "request-promise-native": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
As mentioned [here](https://github.com/request/request-promise-native#installation) `"request is defined as a peer-dependency and thus has to be installed separately."`